### PR TITLE
Bump nusb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,14 +238,16 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "nusb"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8beeee5c0ad012e1eaca540f5610d09a3af58ec435537d511b67e0be36ea66"
+checksum = "b58c5baaf1902712d1c7ef734165376bf1e05f0ebfd00755fd4c4762c06b0c1a"
 dependencies = [
  "atomic-waker",
  "core-foundation",
  "core-foundation-sys",
+ "futures-core",
  "io-kit-sys",
+ "libc",
  "log",
  "once_cell",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ categories = ["api-bindings"]
 atomic_enum = "0.3.0"
 futures-lite = "2.3.0"
 log = "0.4.22"
-# TODO: waiting on https://github.com/kevinmehall/nusb/issues/84 for file descriptor wrapping support
-# nusb = { git = "https://github.com/kevinmehall/nusb.git", rev = "809228038f43de2d7a636825d17439b445f612b7" }
-nusb = "0.1.10"
+nusb = "0.1.11"
 thiserror = "1.0.63"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,6 @@ impl HackRf {
         })
     }
 
-    /*
-    Uncomment after https://github.com/kevinmehall/nusb/issues/84 merges
     /// Wraps a HackRf One exposed through an existing file descriptor.
     ///
     /// Useful on platforms like Android where [`UsbManager`](https://developer.android.com/reference/android/hardware/usb/UsbManager#openAccessory(android.hardware.usb.UsbAccessory)) permits access to an fd.
@@ -103,7 +101,6 @@ impl HackRf {
             mode: AtomicMode::new(Mode::Off),
         })
     }
-    */
 
     /// Opens the first Hackrf One found via USB.
     pub fn open_first() -> Result<HackRf> {


### PR DESCRIPTION
Bumps nusb to [v0.1.11](https://github.com/kevinmehall/nusb/releases/tag/v0.1.11) to gain access to `Device::from_fd`